### PR TITLE
Add GitHub Actions support

### DIFF
--- a/.github/workflows/ci-yaffle.yml
+++ b/.github/workflows/ci-yaffle.yml
@@ -1,0 +1,42 @@
+name: Yaffle
+
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - '*'
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+  workflow_dispatch:
+    branches:
+      - '*'
+
+jobs:
+  ubuntu-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y chezscheme git
+          echo "$HOME/.idris2/bin" >> "$GITHUB_PATH"
+
+      - name: Bootstrap-build Idris2
+        run: |
+          git clone https://github.com/idris-lang/Idris2.git
+          cd Idris2
+          git checkout 23e3695d
+          make bootstrap SCHEME=chezscheme
+          make install
+      - name: Build Yaffle
+        run: |
+          ~/.idris2/bin/idris2 --build 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Yaffle
 ------
 
+[![Yaffle](https://github.com/edwinb/Yaffle/actions/workflows/ci-yaffle.yml/badge.svg)](https://github.com/edwinb/Yaffle/actions/workflows/ci-yaffle.yml)
+
 A core language of quantitative dependent types and an elaborator for an
 intermediate language, and an API, intended as a core language for dependently
 typed languages (primarily, and initially, for Idris 2).


### PR DESCRIPTION
Add GitHub Actions support (+ a status badge in the README)

Notes:
- based on dc41ae34 (currently two commits behind `HEAD`), which is the last commit that builds for me.
- would benefit from some caching