### PR TITLE
[ port ] of PR #2837 - fix issue where at-patterns leak to RHS.

### DIFF
--- a/src/TTImp/WithClause.idr
+++ b/src/TTImp/WithClause.idr
@@ -84,9 +84,9 @@ mutual
       = matchAll True [(f, f'), (a, a)]
   -- On RHS: Rely on unification to fill in the implicit
   getMatch False (INamedApp fc f n a) f'
-      = getMatch False f f
+      = getMatch False f f'
   getMatch False (IAutoApp fc f a) f'
-      = getMatch False f f
+      = getMatch False f f'
   -- Can't have an implicit in the clause if there wasn't a matching
   -- implicit in the parent
   getMatch lhs f (INamedApp fc f' n a)


### PR DESCRIPTION
This PR ports over the fix in idris-lang/Idris2#2837.  

Fixes an issue where an @-pattern is leaked into the right side. It occurs in a recursive call to a `with` clause if there are @ patterns and implicits. A typo in the function `getMatch` causes the left hand side to be used for the right hand side after an implicit is hit.
