### PR TITLE
make cond's default argument lazy

### DIFF
--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -399,7 +399,7 @@ wrapRef x onClose op
        pure o
 
 export
-cond : List (Lazy Bool, Lazy a) -> a -> a
+cond : List (Lazy Bool, Lazy a) -> Lazy a -> a
 cond [] def = def
 cond ((x, y) :: xs) def = if x then y else cond xs def
 


### PR DESCRIPTION
`cond` is not Lazy in its second argument, which cause evaluation of default case all the time.

This PR is related to https://github.com/idris-lang/Idris2/pull/2921

Unfortunately I could not compile Yaffle to verify the change on my local computer.