### PR TITLE
[ total ] Make getters TCInline & add a test for getters producing a smaller value

### DIFF
--- a/src/TTImp/ProcessRecord.idr
+++ b/src/TTImp/ProcessRecord.idr
@@ -264,7 +264,7 @@ elabRecord {vars} eopts fc env nest newns vis mbtot tn_in params0 opts conName_i
 
                    let mkProjClaim = \ nm =>
                           let ty = MkImpTy EmptyFC EmptyFC nm projTy
-                          in IClaim bfc rig isVis [Inline] ty
+                          in IClaim bfc rig isVis [Inline, TCInline] ty
 
                    log "declare.record.projection" 5 $
                       "Projection " ++ show rfNameNS ++ " : " ++ show projTy

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -27,7 +27,7 @@ yaffleTests = MkTestPool "Yaffle" [] Nothing
       "compile001", "compile002",
       "coverage001",
       "qtt001", "qtt002", "qtt003", "qtt004",
-      "record001", "record002",
+      "record001", "record002", "record003",
       "rewrite001",
       "with001",
       -- Below are things that don't test anything specific, but are useful exercises

--- a/tests/yaffle/record003/Record.yaff
+++ b/tests/yaffle/record003/Record.yaff
@@ -1,0 +1,22 @@
+data Unit : Type where
+  MkUnit : Unit
+
+record Id a where
+  constructor MkId
+  field : a
+
+data X : Type where
+  Stop : Unit -> X
+  Cont : Id X -> X
+
+f : X -> Unit
+f (Stop n) = n
+f (Cont x) = f (field x)
+
+field' : Id a -> a
+field' x = case x of
+  MkId y => y
+
+f' : X -> Unit
+f' (Stop n) = n
+f' (Cont x) = f' (field' x)

--- a/tests/yaffle/record003/expected
+++ b/tests/yaffle/record003/expected
@@ -1,0 +1,7 @@
+Processing as TTImp
+Written TTC
+Yaffle> Main.MkUnit
+Yaffle> Main.f is total
+Yaffle> Main.MkUnit
+Yaffle> Main.f' is total
+Yaffle> Bye for now!

--- a/tests/yaffle/record003/input
+++ b/tests/yaffle/record003/input
@@ -1,0 +1,5 @@
+f (Stop MkUnit)
+:total f
+f' (Stop MkUnit)
+:total f'
+:q

--- a/tests/yaffle/record003/run
+++ b/tests/yaffle/record003/run
@@ -1,0 +1,3 @@
+rm -rf build
+$1 --yaffle Record.yaff < input
+


### PR DESCRIPTION
When I run into this behaviour in the current Idris I thought the reason is lack of `%tcinline` for the getter functions. I added it there and it still is not working. Then I thought this is because of the way how `case`s and pattern matches are elaborated. Then I decided to try this in Yaffle and I realised that it also has this problem, somewhy. Even if the getter-like function is defined using explicit `case` clause.