### PR TITLE
[ port ] Ignore `UseSide` annotation in non-linear as-patterns

### DIFF
--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -297,10 +297,12 @@ findLinear top bound rig tm
       findLinArg : {vars : _} ->
                    RigCount -> SnocList (RigCount, Term vars) ->
                    Core (List (Name, RigCount))
-      findLinArg rig (as :< (c, As fc UseLeft _ p))
-          = findLinArg rig (as :< (c, p))
-      findLinArg rig (as :< (c, As fc UseRight p _))
-          = findLinArg rig (as :< (c, p))
+      findLinArg rig (as :< (c, As fc u a p))
+          = if isLinear c
+               then case u of
+                         UseLeft => findLinArg rig (as :< (c, p))
+                         UseRight => findLinArg rig (as :< (c, a))
+               else findLinArg rig (as :< (c, p) :< (c, a))
       findLinArg rig (as :< (c, Local fc idx prf))
           = do let a = nameAt prf
                if idx < bound


### PR DESCRIPTION
The issue addressed in idris-lang/Idris2#2984 is present in Yaffle as well. This causes some build errors to occur in `Data.Linear.Inverse` module in `papers`. This PR adapts @mjustus's fix to Yaffle.

I've decided to not bring corresponding test with this PR, as it is a part on `linear` test pool that has not been moved to Yaffle yet.